### PR TITLE
Fix: improve performance (closes #41)

### DIFF
--- a/geeked/gobang.py
+++ b/geeked/gobang.py
@@ -27,26 +27,20 @@ class GobangSolver:
                 return [[remove_pos[0], remove_pos[1]], [fill_pos[0], fill_pos[1]]]
 
     def _iterate_lines(self):
-        # Rows and columns
         for row in range(self.n):
             yield [(row, c) for c in range(self.n)]
         for col in range(self.n):
             yield [(r, col) for r in range(self.n)]
 
-        # Diagonals (both directions)
-        diag_groups = defaultdict(list)
-        for r in range(self.n):
-            for c in range(self.n):
-                diag_groups[r - c].append((r, c))
-        for group in diag_groups.values():
-            yield sorted(group, key=lambda x: x[0])
-
-        diag_groups = defaultdict(list)
-        for r in range(self.n):
-            for c in range(self.n):
-                diag_groups[r + c].append((r, c))
-        for group in diag_groups.values():
-            yield sorted(group, key=lambda x: x[0])
+        for start_row in range(self.n):
+            yield [(start_row + i, i) for i in range(self.n - start_row)]
+        for start_col in range(1, self.n):
+            yield [(i, start_col + i) for i in range(self.n - start_col)]
+            
+        for start_row in range(self.n):
+            yield [(start_row - i, i) for i in range(start_row + 1)]
+        for start_col in range(1, self.n):
+            yield [(self.n - 1 - i, start_col + i) for i in range(self.n - start_col)]
 
     @staticmethod
     def _count_freq(elements):


### PR DESCRIPTION
## Description
Optimized the `_iterate_lines` method to improve performance by eliminating unnecessary sorting and memory overhead.

## Changes
- Removed `defaultdict` objects that were causing memory overhead
- Eliminated sorting operations in diagonal generation
- Implemented direct diagonal iteration using mathematical progression
- Reduced time complexity from O(n² log n) to O(n²)

## Performance Impact
- **Before**: O(n² log n) due to sorting each diagonal group
- **After**: O(n²) with direct coordinate generation
- Removed memory overhead from intermediate `defaultdict` collections

## Implementation Details
- Main diagonals: Generate by starting from left edge rows, then top edge columns
- Anti-diagonals: Generate by starting from left edge rows (upward), then top edge columns (downward)
- All coordinates are generated in correct order without need for sorting

Closes #41